### PR TITLE
warning警告排除deprecated

### DIFF
--- a/jieba.go
+++ b/jieba.go
@@ -1,7 +1,7 @@
 package gojieba
 
 /*
-#cgo CXXFLAGS: -I./deps -DLOGGING_LEVEL=LL_WARNING -O3 -Wall
+#cgo CXXFLAGS: -I./deps -DLOGGING_LEVEL=LL_WARNING -O3 -Wall  -Wno-deprecated
 #include <stdlib.h>
 #include "jieba.h"
 */


### PR DESCRIPTION
使用 go test 测试分词时会展示多行 deprecated 的warning信息，新增 CXXFLAGS  -Wno-deprecated 可以隐藏相关信息展示，避免干扰正常信息的返回。